### PR TITLE
Adding java buildpack

### DIFF
--- a/build-dir/buildpacks.txt
+++ b/build-dir/buildpacks.txt
@@ -1,2 +1,3 @@
 https://github.com/heroku/heroku-buildpack-ruby.git
 https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-java.git


### PR DESCRIPTION
Requires a corresponding change to the dokku receiver script.

Tested with a fork of the Heroku java-sample code (https://github.com/rnorth/java-sample)
