### PR TITLE
Add Play! framework buildpack - tested OK

### DIFF
--- a/stack/buildpacks.txt
+++ b/stack/buildpacks.txt
@@ -1,3 +1,4 @@
 https://github.com/heroku/heroku-buildpack-ruby.git
 https://github.com/heroku/heroku-buildpack-nodejs.git
 https://github.com/heroku/heroku-buildpack-java.git
+https://github.com/heroku/heroku-buildpack-play.git


### PR DESCRIPTION
Have tested using the standard Heroku Play sample: https://github.com/heroku/template-java-play

The inclusion of OpenJDK in the base stack has enabled this, as I suspected it would.

I expected the Scala buildpack to be working now as well, but encountered memory space issues - suspect more to do with the small VM I'm testing in more than any actual problem. May test the Scala buildpack later and submit a pull request, time permitting.
