### PR TITLE
Match -dev version sqlite to binary version

### DIFF
--- a/stack/packages.txt
+++ b/stack/packages.txt
@@ -15,7 +15,7 @@ libjpeg-dev
 graphicsmagick-libmagick-dev-compat
 libmysqlclient-dev
 libpq-dev
-libsqlite-dev
+libsqlite3-dev
 libssl-dev
 libssl0.9.8
 libxml2-dev


### PR DESCRIPTION
Without libsqlite3-dev package, the gem sqlite3 will not install.
