### PR TITLE
Added Dart VM support via community buildpacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Buildpacks should generally just work, but many of them make assumptions about t
  * [Python](https://github.com/heroku/heroku-buildpack-python)
  * [PHP](https://github.com/heroku/heroku-buildpack-php.git)
  * [Go](https://github.com/kr/heroku-buildpack-go.git)
+ * [Dart](https://github.com/igrigorik/heroku-buildpack-dart.git)
 
 ## Building Buildstep
 

--- a/stack/buildpacks.txt
+++ b/stack/buildpacks.txt
@@ -7,3 +7,4 @@ https://github.com/heroku/heroku-buildpack-php.git
 https://github.com/kr/heroku-buildpack-go.git
 https://github.com/miyagawa/heroku-buildpack-perl.git
 https://github.com/heroku/heroku-buildpack-scala
+https://github.com/igrigorik/heroku-buildpack-dart.git


### PR DESCRIPTION
Added the Dart VM Buildpack, was able to deploy an small Dart App (https://github.com/amscotti/dart_test_app_dokku) onto a Dokku Instance on Rackspace - http://dart.amsrack.co/
