### PR TITLE
update packages so that rmagick can install

### DIFF
--- a/stack/packages.txt
+++ b/stack/packages.txt
@@ -12,7 +12,7 @@ iputils-tracepath
 libevent-dev
 libglib2.0-dev
 libjpeg-dev
-graphicsmagick-libmagick-dev-compat
+libmagickcore-dev
 libmagickwand-dev
 libmysqlclient-dev
 libpq-dev


### PR DESCRIPTION
Before:

```
remote:        Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.
remote:        
remote:        /build/app/vendor/ruby-2.0.0/bin/ruby extconf.rb
remote:        checking for Ruby version >= 1.8.5... yes
remote:        checking for gcc... yes
remote:        checking for Magick-config... yes
remote:        checking for ImageMagick version >= 6.4.9... yes
remote:        checking for HDRI disabled version of ImageMagick... yes
remote:        checking for stdint.h... yes
remote:        checking for sys/types.h... yes
remote:        checking for wand/MagickWand.h... no
remote:        
remote:        Can't install RMagick 2.13.2. Can't find MagickWand.h.
```

I rebuilt the image and confirmed that RMagick will install successfully after these changes. I am not sure if other buildpacks depend explicitly on graphicsmagick-libmagick-dev-compat? Can re-add if they do.
