### PR TITLE
Add buildpack for static websites

### DIFF
--- a/stack/buildpacks.txt
+++ b/stack/buildpacks.txt
@@ -9,5 +9,5 @@ https://github.com/kr/heroku-buildpack-go.git
 https://github.com/miyagawa/heroku-buildpack-perl.git
 https://github.com/heroku/heroku-buildpack-scala
 https://github.com/igrigorik/heroku-buildpack-dart.git
-https://github.com/Kloadut/heroku-buildpack-static.git
+https://github.com/rhy-jot/buildpack-nginx.git
 https://github.com/Kloadut/heroku-buildpack-static-apache.git


### PR DESCRIPTION
This buildpack builds a container with Apache (based on PHP buildpack), and detect index.html file on the pushed directory.

See https://github.com/Kloadut/heroku-buildpack-static
