### PR TITLE
Add run-cli command to run commands in the app env

### DIFF
--- a/stack/builder
+++ b/stack/builder
@@ -52,6 +52,16 @@ default_types=$(ruby -e "require 'yaml';puts (YAML.load_file('$build_root/.relea
 mkdir -p $build_root/.profile.d
 ruby -e "require 'yaml';(YAML.load_file('$build_root/.release')['config_vars'] || {}).each{|k,v| puts \"#{k}=#{v}\"}" > $build_root/.profile.d/config_vars
 
+cat > /exec <<EOF
+#!/bin/bash
+export HOME=/app
+for file in $app_root/.profile.d/*; do source \$file; done
+hash -r
+cd $app_root
+"\$@"
+EOF
+chmod +x /exec
+
 cat > /start <<EOF
 #!/bin/bash
 export HOME=/app
@@ -65,16 +75,6 @@ else
 fi
 EOF
 chmod +x /start
-
-cat > /run-cli <<EOF
-#!/bin/bash
-export HOME=/app
-for file in $app_root/.profile.d/*; do source \$file; done
-hash -r
-cd $app_root
-"\$@"
-EOF
-chmod +x /run-cli
 
 rm -fR /app
 mv /build/app /


### PR DESCRIPTION
Named the command ~~/run-cli~~ `/exec` because `/run` is a directory. Open for other suggestions.

Usage:
`docker run -t -i <image> /exec my-command arg0 arg1 arg..`

Example:
`docker run -t -i <image> /exec printenv`
