### PR TITLE
Add libcurl4-openssl-dev

### DIFF
--- a/stack/packages.txt
+++ b/stack/packages.txt
@@ -9,6 +9,7 @@ ed
 git
 imagemagick
 iputils-tracepath
+libcurl4-openssl-dev
 libevent-dev
 libglib2.0-dev
 libjpeg-dev


### PR DESCRIPTION
The cedar stack has this library installed. 
