### PR TITLE
wait for tar to complete before committing image

### DIFF
--- a/buildstep
+++ b/buildstep
@@ -4,6 +4,7 @@ NAME="$1"
 
 # Place the app inside the container 
 ID=$(cat | docker run -i -a stdin progrium/buildstep /bin/bash -c "mkdir -p /app && tar -xC /app")
+test $(docker wait $ID) -eq 0
 docker commit $ID $NAME > /dev/null
 
 # Run the builder script and attach to view output


### PR DESCRIPTION
this fixes 'cp: cannot stat /app: No such file or directory' during /build/builder execution, which seems to occur more frequently with docker 0.6.x.
