### PR TITLE
Add libjpeg and libpng shared libraries

### DIFF
--- a/stack/packages.txt
+++ b/stack/packages.txt
@@ -13,6 +13,9 @@ libcurl4-openssl-dev
 libevent-dev
 libglib2.0-dev
 libjpeg-dev
+libjpeg62
+libpng12-0
+libpng12-dev
 libmagickcore-dev
 libmagickwand-dev
 libmysqlclient-dev


### PR DESCRIPTION
This is necessary to run my PHP build pack (http://github.com/CHH/heroku-buildpack-php).
