### PR TITLE
Generate en_US.UTF-8 locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,4 @@ ADD ./stack/ /build
 RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /build/prepare
 RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get clean
+RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Even though the LANG environment variable is set to LANG=en_US.UTF-8 by
heroku buildpacks, the locale has not been generated (see the output of
locale -a). In the case of a Ruby app, all strings are defaulted to
US-ASCII.

This commit will generate the en_US.UTF-8 locale.

In the following output, `noutf8` is an ruby app image built against the current buildstep. `withutf8` is the same ruby image built against buildstep with the en_US.UTF-8 locale generated.

```
[buildstep](generate-utf8)$ docker run noutf8 /exec ruby -e "p 'x'.encoding"
#<Encoding:US-ASCII>
[buildstep](generate-utf8)$ docker run withutf8 /exec ruby -e "p 'x'.encoding"
#<Encoding:UTF-8>
```
