### PR TITLE
Install language-pack-en-base to ensure en_US.UTF-8 locale is present

### DIFF
--- a/stack/packages.txt
+++ b/stack/packages.txt
@@ -9,6 +9,7 @@ ed
 git
 imagemagick
 iputils-tracepath
+language-pack-en-base
 libcurl4-openssl-dev
 libevent-dev
 libglib2.0-dev


### PR DESCRIPTION
At least the python Heroku buildpack sets en_US.UTF-8 as the default
locale if none is present. Dokku does not set a default locale, and
without the en_US.UTF-8 locale present this results in an ASCII locale
during the buildstep. Some python packages have UTF-8 encoding in their
source files which causes the buildstep to bomb out with a decoding
error.
