### PR TITLE
Add support for buildpack caching

### DIFF
--- a/buildstep
+++ b/buildstep
@@ -2,19 +2,27 @@
 set -e
 NAME="$1"
 TAG="$2"
+CACHE_DIR="$3"
 
 # Place the app inside the container
 ID=$(cat | docker run -i -a stdin progrium/buildstep /bin/bash -c "mkdir -p /app && tar -xC /app")
 test $(docker wait $ID) -eq 0
 docker commit $ID $NAME $TAG > /dev/null
 
-# Run the builder script and attach to view output
+# Handle a tag by appending it to the image name
 if [[ -z "$TAG" ]]; then
   IMAGE=$NAME
 else
   IMAGE=$NAME:$TAG
 fi
-ID=$(docker run -d $IMAGE /build/builder)
+# Bind mount a host cache dir to /cache inside the container
+if [[ -z "$CACHE_DIR" ]]; then
+  OPTS='-d'
+else
+  OPTS="-d -v $CACHE_DIR:/cache"
+fi
+# Run the builder script and attach to view output
+ID=$(docker run $OPTS $IMAGE /build/builder)
 docker attach $ID
 test $(docker wait $ID) -eq 0
 docker commit $ID $NAME $TAG > /dev/null


### PR DESCRIPTION
Having 2 optional positional args is a bit inelegant I suppose, but you can pass a cache_dir on the command line and ignore tags by doing:
`./buildstep name "" /opt/caching`