### PR TITLE
in cases where the tar already contains app, this was useful

### DIFF
--- a/buildstep
+++ b/buildstep
@@ -3,7 +3,7 @@ set -e
 NAME="$1"
 TAG="$2"
 
-# Place the app inside the container
+# Place the app inside the container. If you already have app inside your tar, use /bin/bash -c "tar -x"
 ID=$(cat | docker run -i -a stdin progrium/buildstep /bin/bash -c "mkdir -p /app && tar -xC /app")
 test $(docker wait $ID) -eq 0
 docker commit $ID $NAME $TAG > /dev/null


### PR DESCRIPTION
to maintain the minimal nature of buildstep, just added a comment instead of code on how to do this
