### PR TITLE
pass bin/release $build_root instead of $app_root

### DIFF
--- a/stack/builder
+++ b/stack/builder
@@ -43,7 +43,7 @@ export REQUEST_ID=$(openssl rand -base64 32)
 $selected_buildpack/bin/compile "$build_root" "$cache_root"
 
 echo "-----> Discovering process types"
-$selected_buildpack/bin/release "$app_root" "$cache_root" > /build/app/.release
+$selected_buildpack/bin/release "$build_root" "$cache_root" > /build/app/.release
 
 if [[ -f "$build_root/Procfile" ]]; then
   types=$(ruby -e "require 'yaml';puts YAML.load_file('$build_root/Procfile').keys().join(', ')")


### PR DESCRIPTION
This is needed by heroku-buildpack-ruby because of the following line in bin/release:

``` ruby
release = Pathname.new(ARGV.first).join("tmp/heroku-buildpack-release-step.yml")
```

That file does not exist in `$app_root` or `$cache_root`.
