### PR TITLE
Use https://github.com/CHH/heroku-buildpack-php as the builtin PHP buildpack

### DIFF
--- a/stack/buildpacks.txt
+++ b/stack/buildpacks.txt
@@ -3,7 +3,7 @@ https://github.com/heroku/heroku-buildpack-nodejs.git
 https://github.com/heroku/heroku-buildpack-java.git
 https://github.com/heroku/heroku-buildpack-play.git
 https://github.com/heroku/heroku-buildpack-python.git
-https://github.com/heroku/heroku-buildpack-php.git
+https://github.com/CHH/heroku-buildpack-php
 https://github.com/heroku/heroku-buildpack-clojure.git
 https://github.com/kr/heroku-buildpack-go.git
 https://github.com/oortcloud/heroku-buildpack-meteorite.git


### PR DESCRIPTION
The default buildpack (https://github.com/heroku/heroku-buildpack-php.git) is broken in the latest version of buildstep. This swaps it for https://github.com/CHH/heroku-buildpack-php for now, fixing issue #33
