### PR TITLE
Added libmcrypt-dev

### DIFF
--- a/stack/packages.txt
+++ b/stack/packages.txt
@@ -18,6 +18,7 @@ libpng12-0
 libpng12-dev
 libmagickcore-dev
 libmagickwand-dev
+libmcrypt-dev
 libmysqlclient-dev
 libpq-dev
 libsqlite3-dev


### PR DESCRIPTION
A pretty handy package to have.

Currently I'm unable to compile [node-rijndael](https://github.com/skeggse/node-rijndael) and other encryption modules.
