### PR TITLE
Add support for jekyll

### DIFF
--- a/stack/buildpacks.txt
+++ b/stack/buildpacks.txt
@@ -12,3 +12,4 @@ https://github.com/heroku/heroku-buildpack-scala
 https://github.com/igrigorik/heroku-buildpack-dart.git
 https://github.com/rhy-jot/buildpack-nginx.git
 https://github.com/Kloadut/heroku-buildpack-static-apache.git
+https://github.com/bacongobbler/heroku-buildpack-jekyll.git


### PR DESCRIPTION
This adds support for jekyll by using https://github.com/bacongobbler/heroku-buildpack-jekyll . This fixes #30.
