### PR TITLE
Add missing heroku's default buildpacks

### DIFF
--- a/stack/buildpacks.txt
+++ b/stack/buildpacks.txt
@@ -5,6 +5,8 @@ https://github.com/heroku/heroku-buildpack-play.git
 https://github.com/heroku/heroku-buildpack-python.git
 https://github.com/heroku/heroku-buildpack-scala.git
 https://github.com/heroku/heroku-buildpack-clojure.git
+https://github.com/heroku/heroku-buildpack-gradle.git
+https://github.com/heroku/heroku-buildpack-grails.git
 https://github.com/CHH/heroku-buildpack-php.git
 https://github.com/kr/heroku-buildpack-go.git
 https://github.com/oortcloud/heroku-buildpack-meteorite.git


### PR DESCRIPTION
Probably makes sense to have all of Heroku's [default buildpacks](https://devcenter.heroku.com/articles/buildpacks#default-buildpacks) available in Dokku:
- gradle
- grails

Minor cleanup of buildpacks.txt
