### PR TITLE
No need to bundle install in Ruby buildpack

### DIFF
--- a/stack/prepare
+++ b/stack/prepare
@@ -25,4 +25,4 @@ xargs -L 1 git clone --depth=1 < /build/buildpacks.txt
 update-alternatives --set ruby /usr/bin/ruby1.9.1
 update-alternatives --set gem /usr/bin/gem1.9.1
 gem install bundler
-cd /build/buildpacks/heroku-buildpack-ruby && bundle install
+cd /build/buildpacks/heroku-buildpack-ruby


### PR DESCRIPTION
As per [the comment here](https://github.com/heroku/heroku-buildpack-ruby/pull/200#issuecomment-32786689), it looks like you shouldn't do a bundle install at all when building the buildpack.
