### PR TITLE
/start loads app-env.sh again to prioritize user defined variables

### DIFF
--- a/stack/builder
+++ b/stack/builder
@@ -65,7 +65,7 @@ default_types=$(ruby -e "require 'yaml';puts (YAML.load_file('$build_root/.relea
 [[ $default_types ]] && echo "       Default process types for $buildpack_name -> $default_types"
 
 mkdir -p $build_root/.profile.d
-ruby -e "require 'yaml';(YAML.load_file('$build_root/.release')['config_vars'] || {}).each{|k,v| puts \"#{k}=${#{k}:#{v}}\"}" > $build_root/.profile.d/config_vars
+ruby -e "require 'yaml';(YAML.load_file('$build_root/.release')['config_vars'] || {}).each{|k,v| puts \"#{k}=\${#{k}:#{v}}\"}" > $build_root/.profile.d/config_vars
 
 cat > /exec <<EOF
 #!/bin/bash


### PR DESCRIPTION
It fixes https://github.com/progrium/dokku/issues/503

No need to create Procfile which contains:
`web: bash -c "[ -f .profile.d/app-env.sh ] && source .profile.d/app-env.sh; bundle exec rails server -p $PORT"`
