### PR TITLE
Run apps as non-root user, take 2

### DIFF
--- a/stack/builder
+++ b/stack/builder
@@ -89,9 +89,9 @@ for file in $app_root/.profile.d/*; do source \$file; done
 hash -r
 cd $app_root
 if [[ -f Procfile ]]; then
-    ruby -e "require 'yaml';puts YAML.load_file('Procfile')['\$1']" | xargs /exec
+    xargs -xa <(ruby -e "require 'yaml';puts YAML.load_file('Procfile')['\$1']") /exec
 else
-    ruby -e "require 'yaml';puts (YAML.load_file('.release')['default_process_types'] || {})['\$1']" | xargs /exec
+    xargs -xa <(ruby -e "require 'yaml';puts (YAML.load_file('.release')['default_process_types'] || {})['\$1']") /exec
 fi
 EOF
 chmod +x /start


### PR DESCRIPTION
Figured I'd take a second pass at this to try and match the existing heroku behavior of not building inside `/tmp` as well as using a random user on each run. (Previous discussion in #42).

The change consists of starting the container with the root user, creating a non-privileged random user, and executing the passed command as that user.
