### PR TITLE
Don't add config_vars from release to .profile.d

### DIFF
--- a/stack/builder
+++ b/stack/builder
@@ -64,9 +64,6 @@ fi
 default_types=$(ruby -e "require 'yaml';puts (YAML.load_file('$build_root/.release')['default_process_types'] || {}).keys().join(', ')")
 [[ $default_types ]] && echo "       Default process types for $buildpack_name -> $default_types"
 
-mkdir -p $build_root/.profile.d
-ruby -e "require 'yaml';(YAML.load_file('$build_root/.release')['config_vars'] || {}).each{|k,v| puts \"#{k}=#{v}\"}" > $build_root/.profile.d/config_vars
-
 cat > /exec <<EOF
 #!/bin/bash
 export HOME=/app


### PR DESCRIPTION
As described in progrium/dokku#503, config_vars are largely ignored in buildpacks now that they can add .profile.d scripts instead, and including them in this fashion violates their intended behavior.
