### PR TITLE
Only source files in .profile.d ending in .sh

### DIFF
--- a/stack/builder
+++ b/stack/builder
@@ -70,7 +70,7 @@ ruby -e "require 'yaml';(YAML.load_file('$build_root/.release')['config_vars'] |
 cat > /exec <<EOF
 #!/bin/bash
 export HOME=/app
-for file in $app_root/.profile.d/*; do source \$file; done
+for file in $app_root/.profile.d/*.sh; do source \$file; done
 hash -r
 cd $app_root
 "\$@"
@@ -80,7 +80,7 @@ chmod +x /exec
 cat > /start <<EOF
 #!/bin/bash
 export HOME=/app
-for file in $app_root/.profile.d/*; do source \$file; done
+for file in $app_root/.profile.d/*.sh; do source \$file; done
 hash -r
 cd $app_root
 if [[ -f Procfile ]]; then


### PR DESCRIPTION
This aligns buildstep's behavior more closely with that of Heroku.

As described at https://devcenter.heroku.com/articles/profiled:

> The scripts must be bash scripts, and their filenames must end in .sh.
