### PR TITLE
Copy and run prepare before builder to better leverage docker caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM ubuntu:14.04
 MAINTAINER progrium "progrium@gmail.com"
 
 RUN mkdir /build
-ADD ./stack/ /build
+ADD ./stack/prepare /build/prepare
+ADD ./stack/buildpacks.txt /build/buildpacks.txt
+ADD ./stack/packages.txt /build/packages.txt
 RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /build/prepare
 RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get clean
+
+ADD ./stack/builder /build/builder


### PR DESCRIPTION
ATM, every time I do a change on `./stack/builder` file, and run `make build`, it downloads all the packages and it takes forever!
`/prepare` is a slow operation, so we need to make sure we only run it, when strictly necessary, so we cannot copy  the entire `/stack` folder, because if any change happens in it, for instance a change on `builder`, it would invalidate the cache from the point on, and run prepare again.

review @progrium
