### PR TITLE
Fix bundler cache that was not working.

### DIFF
--- a/stack/builder
+++ b/stack/builder
@@ -50,6 +50,8 @@ fi
 
 # generate a random request id used by buildpack instrumentation
 export REQUEST_ID=$(openssl rand -base64 32)
+# choose a stack for the buildpack to use
+export STACK=cedar
 
 $selected_buildpack/bin/compile "$build_root" "$cache_root"
 


### PR DESCRIPTION
After https://github.com/heroku/heroku-buildpack-ruby/commit/3e01277685abbdba1ad2c73b39b9c11bc5d66096
heroku-buildpack-ruby needs a STACK env var, otherwise it will prune the
vendor cache in every compile run.
If no stack given, the buildpack will assume we are changing stacks in
every deploy.
See https://github.com/heroku/heroku-buildpack-ruby/blob/3e01277685abbdba1ad2c73b39b9c11bc5d66096/lib/language_pack/ruby.rb#L752
review @progrium 
cc @hone

working for me after this PR, logs https://gist.github.com/arthurnn/ef6b23d6846f8fe5379a
