### PR TITLE
Make sure libreadline5 is installed.  Closes GH-93

### DIFF
--- a/stack/packages.txt
+++ b/stack/packages.txt
@@ -21,6 +21,7 @@ libmagickwand-dev
 libmcrypt-dev
 libmysqlclient-dev
 libpq-dev
+libreadline5
 libsqlite3-dev
 libssl-dev
 libssl0.9.8


### PR DESCRIPTION
The new Trusty container doesn't include libreadline.so.5 which is required by the PHP buildpack and a few others. This patch updates packages.txt (thanks @michaelshobbs) include libreadline5 in the base buildstep image.
