### PR TITLE
Hardcode stack name

### DIFF
--- a/stack/builder
+++ b/stack/builder
@@ -50,6 +50,7 @@ fi
 
 # generate a random request id used by buildpack instrumentation
 export REQUEST_ID=$(openssl rand -base64 32)
+export STACK=cedar
 
 $selected_buildpack/bin/compile "$build_root" "$cache_root"
 


### PR DESCRIPTION
The newer heroku buildpackes (for example ruby/rails) use the STACK
variable for caching and cache busting (due to the cedar-14 stack).
Without a STACK envvar the caching system is broken and results in the
whole set of gems being reinstalled

For more info please visit: https://github.com/dokku-alt/progrium-buildstep-dockerfiles/pull/2
