### PR TITLE
Replaced CHH's buildpack with official one.

### DIFF
--- a/stack/buildpacks.txt
+++ b/stack/buildpacks.txt
@@ -8,7 +8,7 @@ https://github.com/heroku/heroku-buildpack-scala.git
 https://github.com/heroku/heroku-buildpack-clojure.git
 https://github.com/heroku/heroku-buildpack-gradle.git
 https://github.com/heroku/heroku-buildpack-grails.git
-https://github.com/CHH/heroku-buildpack-php.git
+https://github.com/heroku/heroku-buildpack-php.git
 https://github.com/kr/heroku-buildpack-go.git
 https://github.com/oortcloud/heroku-buildpack-meteorite.git
 https://github.com/miyagawa/heroku-buildpack-perl.git

--- a/stack/packages.txt
+++ b/stack/packages.txt
@@ -19,8 +19,10 @@ libpng12-dev
 libmagickcore-dev
 libmagickwand-dev
 libmcrypt-dev
+libmcrypt4
 libmysqlclient-dev
 libpq-dev
+libreadline5
 libsqlite3-dev
 libssl-dev
 libssl0.9.8


### PR DESCRIPTION
Hi there,

Because Christoph is no longer maintaining his buildpack and Heroku came with its own, I replaced the buildpack with the official one. You can try it out as Docker image [here](https://registry.hub.docker.com/u/robinvdvleuten/buildstep/).

Cheers,
Robin
