### PR TITLE
fix parsing of an empty yaml file generated by a releases script

### DIFF
--- a/builder/compile.sh
+++ b/builder/compile.sh
@@ -81,12 +81,12 @@ if [[ -f "$build_root/Procfile" ]]; then
 fi
 default_types=""
 if [[ -f "$build_root/.release" ]]; then
-  default_types=$(ruby -e "require 'yaml';puts (YAML.load_file('$build_root/.release')['default_process_types'] || {}).keys().join(', ')")
+  default_types=$(ruby -e "require 'yaml';puts ((YAML.load_file('$build_root/.release') || {})['default_process_types'] || {}).keys().join(', ')")
   [[ $default_types ]] && echo_normal "Default process types for $buildpack_name -> $default_types"
 fi
 
 ## Export release config
 
 if [[ -f "$build_root/.release" ]]; then
-  ruby -e "require 'yaml';(YAML.load_file('$build_root/.release')['config_vars'] || {}).each{|k,v| puts \"export #{k}='#{v}'\"}" > $build_root/.profile.d/00_config_vars.sh
+  ruby -e "require 'yaml';((YAML.load_file('$build_root/.release') || {})['config_vars'] || {}).each{|k,v| puts \"export #{k}='#{v}'\"}" > $build_root/.profile.d/00_config_vars.sh
 fi


### PR DESCRIPTION
This was caused for me by the `---\n` releases output generated by heroku-buildpack-buildout[1].

[1] https://github.com/niteoweb/heroku-buildpack-buildout/blob/5879fa3418f7d8e079f1aa5816ba1adde73f4948/bin/release