### PR TITLE
Allow the user to be set via an environment variable.

### DIFF
--- a/builder/builder
+++ b/builder/builder
@@ -8,8 +8,19 @@ mkdir -p $cache_root
 mkdir -p $buildpack_root
 mkdir -p $build_root/.profile.d
 
-user_id=$((RANDOM+1000))
-user_name="u${user_id}"
+if [ "$USER_ID" == "" ];
+then
+	user_id=$((RANDOM+1000));
+else
+	user_id=$USER_ID;
+fi
+
+if [ "$USER_NAME" == "" ];
+then
+	user_name="u${user_id}";
+else
+	user_name=$USER_NAME;
+fi
 
 # Create a random user
 /usr/sbin/addgroup --quiet --gid $user_id $user_name


### PR DESCRIPTION
Hi,

In #133 I suggested that it would be useful to allow the user to control both the user via an environmental variable. This PR contains the solution that works for my use case, and I'm hoping we can build on it to reach something that can be merged into the project :)

I needed a way of mounting a volume (either from the host, or a data container) for persistent storage within the app, but keeping the permissions reasonably simple (in terms of understanding).  My main issue was that over the course of subsequent deploys, the container that originally wrote files to the persistent storage area was no longer able to manipulate them. It also made it difficult to share files with non-Dokku containers. I also wanted to avoid having to continuously re-`chown`'ing the files as the user changed.

This PR can be used in conjunction with the persistent storage plugin (https://github.com/dyson/dokku-persistent-storage) in order to populate the variables at build time, e.g.:

    $ dokku docker-options example
    -e USER_ID=1234
    -e USER_NAME=example

Thanks,
Jay